### PR TITLE
feat: add and update domains in Direct and WARP lists

### DIFF
--- a/Surge/Direct.list
+++ b/Surge/Direct.list
@@ -1,13 +1,13 @@
 # NAME: Direct
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/Direct.list
-# DOMAIN: 8
+# DOMAIN: 13
 # DOMAIN-KEYWORD: 0
-# DOMAIN-SUFFIX: 1
+# DOMAIN-SUFFIX: 3
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 9
+# TOTAL: 16
 
 DOMAIN,tuic1.dast.tw
 DOMAIN,tuic2.dast.tw
@@ -18,4 +18,10 @@ DOMAIN,cn.pornhub.com
 DOMAIN,e-hentai.org
 DOMAIN,exhentai.org
 DOMAIN,www.ctbcbank.com
+DOMAIN,watther-data.apple.com
+DOMAIN,kt-prod.ess.apple.com
+DOMAIN,gateway.icloud.com
+DOMAIN,amp-api-podcasts.apple.com
+DOMAIN-SUFFIX,ls.apple.com
+DOMAIN-SUFFIX,itunes.apple.com
 DOMAIN-SUFFIX,gandi.net

--- a/Surge/WARP.list
+++ b/Surge/WARP.list
@@ -1,18 +1,26 @@
 # NAME: Cloudflare WARP
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/WARP.list
-# DOMAIN: 4
+# DOMAIN: 14
 # DOMAIN-SUFFIX: 1
 # DOMAIN-KEYWORD: 0
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 5
+# TOTAL: 16
 
-# DOMAIN,imap.gmail.com
+DOMAIN,imap.gmail.com
 DOMAIN,www06.eyny.com
 DOMAIN,www.sex.com
 DOMAIN,www.mobile01.com
+DOMAIN,blog.dast.tw
 DOMAIN,dns.dast.tw
-# DOMAIN-SUFFIX,mail.me.com
-DOMAIN-SUFFIX,dast.tw
+DOMAIN,happy2you.dast.tw
+DOMAIN,nas.dast.tw
+DOMAIN,nts.dast.tw
+DOMAIN,pve.dast.tw
+DOMAIN,shadow.dast.tw
+DOMAIN,unifi.dast.tw
+DOMAIN,uptime.dast.tw
+DOMAIN,weifan-nas.dast.tw
+DOMAIN-SUFFIX,mail.me.com


### PR DESCRIPTION
- Update `Direct.list` to include 3 new domains
- Change the `DOMAIN` count in `Direct.list` from `8` to `13`
- Update `WARP.list` to include 12 new domains
- Change the `DOMAIN` count in `WARP.list` from `4` to `14`
- Remove a commented out line in `WARP.list`
- Add a domain to `Direct.list` with `watther-data.apple.com`
- Add 5 new domains to `WARP.list` and a `DOMAIN-SUFFIX` for `itunes.apple.com` and `ls.apple.com`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
