### PR TITLE
chore: adjust domain and suffix values in Surge config

### DIFF
--- a/Surge/Direct.list
+++ b/Surge/Direct.list
@@ -1,13 +1,13 @@
 # NAME: Direct
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/Direct.list
-# DOMAIN: 15
+# DOMAIN: 13
 # DOMAIN-KEYWORD: 0
-# DOMAIN-SUFFIX: 4
+# DOMAIN-SUFFIX: 3
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 19
+# TOTAL: 16
 
 DOMAIN,tuic1.dast.tw
 DOMAIN,tuic2.dast.tw
@@ -17,14 +17,11 @@ DOMAIN,www.jkforum.net
 DOMAIN,cn.pornhub.com
 DOMAIN,e-hentai.org
 DOMAIN,exhentai.org
-DOMAIN-SUFFIX,gandi.net
 DOMAIN,www.ctbcbank.com
-DOMAIN,gateway.fe.apple-dns.net
-DOMAIN,probe.me.apple-dns.net
 DOMAIN,gateway.icloud.com
 DOMAIN,watther-data.apple.com
 DOMAIN,amp-api-podcasts.apple.com
 DOMAIN,kt-prod.ess.apple.com
+DOMAIN-SUFFIX,gandi.net
 DOMAIN-SUFFIX,ls.apple.com
 DOMAIN-SUFFIX,init.ess.apple.com
-DOMAIN-SUFFIX,itunes.apple.com

--- a/Surge/WARP.list
+++ b/Surge/WARP.list
@@ -1,15 +1,14 @@
 # NAME: Cloudflare WARP
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/WARP.list
-# DOMAIN: 13
-# DOMAIN-SUFFIX: 1
+# DOMAIN: 12
+# DOMAIN-SUFFIX: 2
 # DOMAIN-KEYWORD: 0
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
 # TOTAL: 14
 
-DOMAIN,imap.gmail.com
 DOMAIN,www06.eyny.com
 DOMAIN,www.sex.com
 DOMAIN,www.mobile01.com
@@ -23,3 +22,4 @@ DOMAIN,uptime.dast.tw
 DOMAIN,shadow.dast.tw
 DOMAIN,weifan-nas.dast.tw
 DOMAIN-SUFFIX,mail.me.com
+DOMAIN-SUFFIX,imap.gmail.com


### PR DESCRIPTION
- Decreased the value of `DOMAIN` from 15 to 13 in `Surge/Direct.list`
- Decreased the value of `DOMAIN-SUFFIX` from 4 to 3 in `Surge/Direct.list`
- Decreased the value of `TOTAL` from 19 to 16 in `Surge/Direct.list`
- Removed the line `DOMAIN-SUFFIX,gandi.net` in `Surge/Direct.list`
- Removed the lines `DOMAIN,gateway.fe.apple-dns.net` and `DOMAIN,probe.me.apple-dns.net` in `Surge/Direct.list`
- Added the line `DOMAIN-SUFFIX,gandi.net` in `Surge/Direct.list`
- Removed the line `DOMAIN,imap.gmail.com` in `Surge/WARP.list`
- Added the line `DOMAIN-SUFFIX,imap.gmail.com` in `Surge/WARP.list`
- Decreased the value of `DOMAIN` from 13 to 12 in `Surge/WARP.list`
- Increased the value of `DOMAIN-SUFFIX` from 1 to 2 in `Surge/WARP.list`

Signed-off-by: DAST-Macbook <jackie@dast.tw>
