### PR TITLE
chore: update domain configurations in Surge

### DIFF
--- a/Surge/Direct.list
+++ b/Surge/Direct.list
@@ -3,14 +3,15 @@
 # REPO: https://github.com/cloverdefa/Rule-Sets/Direct.list
 # DOMAIN: 13
 # DOMAIN-KEYWORD: 0
-# DOMAIN-SUFFIX: 3
+# DOMAIN-SUFFIX: 1
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 16
+# TOTAL: 14
 
 DOMAIN,tuic1.dast.tw
 DOMAIN,tuic2.dast.tw
+DOMAIN,dns.dast.tw
 DOMAIN,dast.tw
 DOMAIN,www.dast.tw
 DOMAIN,www.jkforum.net
@@ -21,7 +22,4 @@ DOMAIN,www.ctbcbank.com
 DOMAIN,gateway.icloud.com
 DOMAIN,watther-data.apple.com
 DOMAIN,amp-api-podcasts.apple.com
-DOMAIN,kt-prod.ess.apple.com
 DOMAIN-SUFFIX,gandi.net
-DOMAIN-SUFFIX,ls.apple.com
-DOMAIN-SUFFIX,init.ess.apple.com

--- a/Surge/WARP.list
+++ b/Surge/WARP.list
@@ -1,18 +1,17 @@
 # NAME: Cloudflare WARP
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/WARP.list
-# DOMAIN: 12
+# DOMAIN: 11
 # DOMAIN-SUFFIX: 2
 # DOMAIN-KEYWORD: 0
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 14
+# TOTAL: 13
 
 DOMAIN,www06.eyny.com
 DOMAIN,www.sex.com
 DOMAIN,www.mobile01.com
-DOMAIN,dns.dast.tw
 DOMAIN,nts.dast.tw
 DOMAIN,unifi.dast.tw
 DOMAIN,nas.dast.tw


### PR DESCRIPTION
- Change in `Surge/Direct.list`: The `DOMAIN-SUFFIX` count has been reduced from 3 to 1 and the `TOTAL` count has been reduced from 16 to 14.
- Change in `Surge/Direct.list`: A new domain `DOMAIN,dns.dast.tw` has been added.
- Change in `Surge/Direct.list`: Two domains, `DOMAIN,kt-prod.ess.apple.com` and `DOMAIN-SUFFIX,ls.apple.com`, have been removed.
- Change in `Surge/Direct.list`: The domain `DOMAIN-SUFFIX,init.ess.apple.com` has been removed.
- Change in `Surge/WARP.list`: The `DOMAIN` count has been reduced from 12 to 11 and the `TOTAL` count has been reduced from 14 to 13.
- Change in `Surge/WARP.list`: The domain `DOMAIN,dns.dast.tw` has been removed.

Signed-off-by: DAST-Macbook <jackie@dast.tw>
