### PR TITLE
chore: update pascalgn/automerge-action to v0.15.6

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automerge
-        uses: 'pascalgn/automerge-action@v0.14.3'
+        uses: 'pascalgn/automerge-action@v0.15.6'
         env:
           GITHUB_TOKEN: '${{ secrets.RELEASE_TOKEN }}'
           MERGE_LABELS: ''


### PR DESCRIPTION
- Update the `pascalgn/automerge-action` version from `v0.14.3` to `v0.15.6` in the `.github/workflows/auto-merge.yml` file

Signed-off-by: DAST-Macbook <jackie@dast.tw>
