### PR TITLE
chore: ignore `pyproject.toml` and `poetry.lock` in the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,12 @@
 .md
 *.code-workspace
 *.spec
+pyproject.toml
+poetry.lock
 
 # 忽略資料夾
 __pycache__/
+.venv/
 .vscode/
 build/
 dist/


### PR DESCRIPTION
- Added `pyproject.toml` and `poetry.lock` to the `.gitignore` file

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
