### PR TITLE
ci: add Telegram notification workflow for push events

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,34 @@
+name: Telegram Notification Push
+
+# 要在什麼時候觸發，實測只設定 push 沒有限定更細的 type 或條件時，
+# 新增 tag、設定 release 等活動都會觸發
+on:
+  push
+
+# 設定 job 的內容
+jobs:
+
+  bulid:
+    # 被觸發後，點進上面的名稱後，這邊的名稱會顯示在流程頁面中
+    name: Build
+    # action 執行的環境
+    runs-on: ubuntu-latest
+    steps:
+    # 再點入上面的流程看詳細執行狀況時，會顯示下面的名字
+    - name: send message on push
+      # 使用這個專案已經寫好的 action
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.BOT_ID }}
+        token: ${{ secrets.BOT_TOKEN }}
+        # 設定要發出的訊息格式，以下是參考原始 repo 後稍微改寫的設定
+        # github.actor: 觸發 event 的使用者名稱
+        # github.sha: commit 的 hash 值
+        # github.event.commits[0].message: commit message
+        # github.repository: repository 的名稱
+        message: |
+           ${{ github.actor }} created commit: 
+           Commit message: ${{ github.event.commits[0].message }}
+           Repository: ${{ github.repository }}
+
+           https://github.com/${{ github.repository }}/commit/${{github.sha}}


### PR DESCRIPTION
- Add a new file `.github/workflows/bot.yml`
- Set up a workflow to trigger on push events
- Add a job named "Build" to the workflow
- Use the `appleboy/telegram-action` action to send a message on push
- Configure the action with the recipient and token secrets
- Customize the message format with information about the commit and repository

Signed-off-by: HomePC-DAST <jackie@dast.tw>
