### PR TITLE
重構：從udn.com中刪除不必要的元素

### DIFF
--- a/AGH/block-list.txt
+++ b/AGH/block-list.txt
@@ -6,6 +6,16 @@
 ||telegramio.org^
 ||902-telegarm.com^
 
+! 中央社 CNA https://www.cna.com.tw
+! 首頁右側、文章列表右側、內文中：訂閱提醒
+www.cna.com.tw#%#//scriptlet('set-cookie-reload', 'CnaCloseLanguage', '1')
+www.cna.com.tw#$#div[class="centralContent"] { max-width: unset !important; }
+www.cna.com.tw##div[class^="paragraph moreArticle"]
+www.cna.com.tw##div[class="paragraph bottomBox"]
+www.cna.com.tw##div[class="paragraph BtnShareGroup appDownload"]
+www.cna.com.tw##div[class="nav"]
+www.cna.com.tw##.mySubscriptionInner
+
 ! 聯合新聞網 UDN https://udn.com
 udn.com###ultraDesktopBanner
 udn.com##div[class="tools-box"]


### PR DESCRIPTION
- 從封鎖清單中刪除“902-telegarm.com”
- 為“www.cna.com.tw”添加自定義CSS規則
- 從“udn.com”中刪除“ultraDesktopBanner”
- 從“udn.com”中刪除“tools-box”
- 從“udn.com”中刪除“breaking-news__wrapper”
- 從“udn.com”中刪除“aside”
