### PR TITLE
功能: 更新新聞網站的封鎖規則

### DIFF
--- a/AGH/block-list.txt
+++ b/AGH/block-list.txt
@@ -36,6 +36,8 @@ udn.com##section[class="facebook-comment article-section context-box"]
 udn.com##section[class="discuss-board article-section context-box"]
 udn.com#$#.wrapper-left { width: unset !important; }
 udn.com#$#.footer { margin-top: unset !important; }
+udn.com##div[id="taboola-below-discuss-thumbnails"]
+[$path=/news]udn.com##a[href^="https://udn.com/vote2024/story/"]:nth-ancestor(2)
 
 ! UDN 寵物
 pets.udn.com##div[class="story variety extend"]
@@ -64,7 +66,8 @@ news.ltn.com.tw##div[id="marqueeHeader"]
 news.ltn.com.tw##div[class="related boxTitle"]
 news.ltn.com.tw##div[class="see_more boxTitle"]
 news.ltn.com.tw##div[class="todaynews boxTitle"]
-news.ltn.com.tw##div[class=“footermenu”]
+news.ltn.com.tw##div[class="footermenu"]
+news.ltn.com.tw##div[data-desc="重要專題"]:nth-ancestor(1)
 
 3c.ltn.com.tw##aside
 3c.ltn.com.tw##div[class="top boxTitle boxText"]


### PR DESCRIPTION
- 新增兩個針對 `udn.com` 和 `[path=/news]udn.com` 的封鎖規則
- 移除針對 `pets.udn.com` 的封鎖規則
- 修正 `news.ltn.com.tw` 選擇器中的拼字錯誤
- 新增針對 `news.ltn.com.tw` 的封鎖規則
- 移除針對 `3c.ltn.com.tw` 的封鎖規則

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
