### PR TITLE
功能：為UDN寵物版塊添加區塊規則

### DIFF
--- a/AGH/block-list.txt
+++ b/AGH/block-list.txt
@@ -33,6 +33,8 @@ udn.com##section[class="facebook-comment article-section context-box"]
 udn.com##section[class="discuss-board article-section context-box"]
 udn.com#$#.wrapper-left { width: unset !important; }
 udn.com#$#.footer { margin-top: unset !important; }
+udn.com##div[id="taboola-below-discuss-thumbnails"]
+[$path=/news]udn.com##a[href^="https://udn.com/vote2024/story/"]:nth-ancestor(2)
 
 ! UDN 寵物
 pets.udn.com##div[class="story variety extend"]


### PR DESCRIPTION
- 在AGH目錄的block-list.txt文件中添加兩個新規則
- 添加的規則針對udn.com網站上的特定元素
- 一個規則針對具有特定ID的div，另一個規則針對/news頁面上的特定鏈接
- 這些規則是為了阻止某些元素在網站上顯示
- 這些更改與阻止UDN寵物版塊上的內容有關

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
