### PR TITLE
工作: 新增 ai-internationalxc.com 的封鎖清單項目

### DIFF
--- a/AGH/block-list.txt
+++ b/AGH/block-list.txt
@@ -24,6 +24,7 @@
 ||wbe-Telegran.com^
 ||www.thelikooei.xyz^
 ||avhu.com^
+||ai-internationalxc.com^$dnsrewrite=NOERROR;A;34.102.218.71
 
 ! 中央社 CNA https://www.cna.com.tw
 ! 首頁右側、文章列表右側、內文中：訂閱提醒


### PR DESCRIPTION
- 在 block-list.txt 檔案新增一個新項目
- 新項目是針對域名 "ai-internationalxc.com" 的 DNS 重寫設定
- 該域名的 IP 地址為 34.102.218.71
- 如果 DNS 查詢返回 NOERROR 響應，則排除該域名的重寫
