### PR TITLE
CHORE: 更新 ChatGPT 的允許清單以包含 chat.openai.com

### DIFF
--- a/AGH/allow-list.txt
+++ b/AGH/allow-list.txt
@@ -31,6 +31,9 @@
 ! Cloudflare
 @@||*.cloudflare.com^
 
+! ChatGPT
+@@||chat.openai.com^
+
 ! Apple
 @@||*.apple.com^
 @@||gateway.icloud.com^


### PR DESCRIPTION
- 增加 `ChatGPT` 的允許清單項目，允許 `chat.openai.com`

Signed-off-by: Macbook <jackie@dast.tw>
