### PR TITLE
chore: standardize domains in network configurations

### DIFF
--- a/Surge/Localdomain.list
+++ b/Surge/Localdomain.list
@@ -9,9 +9,7 @@
 # USER-AGENT: 0
 # TOTAL: 14
 
-DOMAIN,uckh.local
+DOMAIN,uckh.localdomain
 DOMAIN,nas-dast.localdomain
-DOMAIN,nas-dast.local
-DOMAIN,homebridge.local
+DOMAIN,homebridge.localdomain
 DOMAIN,nas2-dast.localdomain
-DOMAIN,nas2-dast.local


### PR DESCRIPTION
- Change domain from `uckh.local` to `uckh.localdomain`
- Change domain from `homebridge.local` to `homebridge.localdomain`
- Remove entries for `nas-dast.local` and `nas2-dast.local`

Signed-off-by: Macbook <jackie@dast.tw>
