### PR TITLE
chore: update dependency versions and configurations in GitHub Actions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: "pascalgn/automerge-action@v0.16.3"
+        uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
-          MERGE_LABELS: ''
-          MERGE_FILTER_AUTHOR: 'cloverdefa'
+          MERGE_LABELS: ""
+          MERGE_FILTER_AUTHOR: "cloverdefa"


### PR DESCRIPTION
- Update the version of `pascalgn/automerge-action` to `v0.16.4`
- Clear out the `MERGE_LABELS` value, changing it to an empty string
- Update the `MERGE_FILTER_AUTHOR` value to `"cloverdefa"`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
