### PR TITLE
fix: improve TELEGRAM ad delivery targeting restrictions

### DIFF
--- a/AGH/block-list.txt
+++ b/AGH/block-list.txt
@@ -29,6 +29,3 @@
 ||w-vvhatsapp.com^
 ||signin.authen-connexion.info^
 
-! 阻擋TELEGRAM連線廣告推送
-||95.161.76.100/31
-


### PR DESCRIPTION
- Remove block on TELEGRAM connection ads
- Removed IP address block for TELEGRAM ads

Signed-off-by: HomePC-WSL <jackie@dast.tw>
