### PR TITLE
chore: update allow-list entries and remove outdated ones

### DIFF
--- a/AGH/allow-list.txt
+++ b/AGH/allow-list.txt
@@ -42,6 +42,3 @@
 @@||*.apple.com^
 @@||gateway.icloud.com^
 
-! Yiwen
-@@||*.hlh.org.tw^
-


### PR DESCRIPTION
- Remove `Yiwen` from the allow-list
- Update entries in the allow-list for `*.apple.com` and `gateway.icloud.com`
- Remove outdated entry for `*.hlh.org.tw`

Signed-off-by: Macbook <jackie@dast.tw>
