### PR TITLE
增加系統中的域名和條目計數

### DIFF
--- a/Surge/Direct.list
+++ b/Surge/Direct.list
@@ -1,17 +1,18 @@
 # NAME: Direct
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/Direct.list
-# DOMAIN: 8
+# DOMAIN: 9
 # DOMAIN-KEYWORD: 0
 # DOMAIN-SUFFIX: 2
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 10
+# TOTAL: 11
 
 DOMAIN,h1.dast.tw
 DOMAIN,h2.dast.tw
 DOMAIN,h3.dast.tw
+DOMAIN,dns.dast.tw
 DOMAIN,github.com
 DOMAIN,www.jkforum.net
 DOMAIN,cn.pornhub.com
@@ -19,5 +20,4 @@ DOMAIN,e-hentai.org
 DOMAIN,exhentai.org
 DOMAIN-SUFFIX,ctbcbank.com
 DOMAIN-SUFFIX,gandi.net
-
 


### PR DESCRIPTION
功能：增加系統中的域名和條目計數

- 將域名計數從 8 更新至 9
- 將總計數從 10 增加至 11
- 為 dns.dast.tw 新增一個域名條目

Signed-off-by: DAST <jackie@dast.tw>
