### PR TITLE
更新 Localdomain 和 WARP 列表以進行域名管理

### DIFF
--- a/Surge/Localdomain.list
+++ b/Surge/Localdomain.list
@@ -1,20 +1,21 @@
 # NAME: Localdomain
 # AUTHOR: DAST
 # REPO: https://github.com/cloverdefa/Rule-Sets/Localdomain.list
-# DOMAIN: 8
+# DOMAIN: 9
 # DOMAIN-KEYWORD: 0
 # DOMAIN-SUFFIX: 0
 # IP-CIDR: 0
 # PROCESS-NAME: 0
 # USER-AGENT: 0
-# TOTAL: 8
+# TOTAL: 9
 
-DOMAIN,uckh.localdomain
-DOMAIN,nas-dast.localdomain
-DOMAIN,pve.localdomain
 DOMAIN,agh.localdomain
+DOMAIN,dns.dast.tw
 DOMAIN,ha.localdomain
-DOMAIN,office-router.localdomain
-DOMAIN,ucko.localdomain
+DOMAIN,nas-dast.localdomain
 DOMAIN,nas2-dast.localdomain
+DOMAIN,office-router.localdomain
+DOMAIN,pve.localdomain
+DOMAIN,uckh.localdomain
+DOMAIN,ucko.localdomain
 

--- a/Surge/WARP.list
+++ b/Surge/WARP.list
@@ -9,17 +9,17 @@
 # USER-AGENT: 0
 # TOTAL: 18
 
-DOMAIN,www06.eyny.com
-DOMAIN,www.mobile01.com
 DOMAIN,ansible.dast.tw
+DOMAIN,blog.dast.tw
+DOMAIN,nas.dast.tw
 DOMAIN,nts.dast.tw
+DOMAIN,pve.dast.tw
+DOMAIN,shadow.dast.tw
 DOMAIN,unifi-home.dast.tw
 DOMAIN,unifi-office.dast.tw
-DOMAIN,nas.dast.tw
-DOMAIN,blog.dast.tw
-DOMAIN,pve.dast.tw
 DOMAIN,uptime.dast.tw
-DOMAIN,shadow.dast.tw
+DOMAIN,www.mobile01.com
+DOMAIN,www06.eyny.com
 DOMAIN,weifan-nas.dast.tw
 DOMAIN,weifan-unvr.dast.tw
 DOMAIN-SUFFIX,mangacopy.com


### PR DESCRIPTION
雜務：更新 Localdomain 和 WARP 列表以進行域名管理

- 將 Localdomain 列表中的域名數量從 8 更新至 9
- 將其他域名新增至 Localdomain 列表
- 刪除 Localdomain 列表中的重複項目
- 在 WARP 列表中新增域名，同時刪除一些現有的域名
- 更新兩個列表中的域名數量並確保沒有重複項目

Signed-off-by: DAST <jackie@dast.tw>
