### PR TITLE
fix: 清理允許清單，移除過時及重複項目

### DIFF
--- a/AGH/allow-list.txt
+++ b/AGH/allow-list.txt
@@ -19,27 +19,3 @@
 @@||h2.dast.tw^
 @@||h3.dast.tw^
 
-! E-Hentai
-@@||e-hentai.org^
-@@||exhentai.org^
-@@||*.hath.network^
-
-! Hentai Network
-@@||*.hath.network^
-
-! UI
-@@||*.ui.com^
-
-! Github
-@@||github.com^
-
-! Cloudflare
-@@||*.cloudflare.com^
-
-! ChatGPT
-@@||chat.openai.com^
-
-! Apple
-@@||*.apple.com^
-@@||gateway.icloud.com^
-


### PR DESCRIPTION
- 從允許清單中移除多個條目，包括與 E-Hentai、Hentai Network、UI、Github、Cloudflare、ChatGPT 及 Apple 網域相關的項目。

Signed-off-by: Macbook Air <jackie@dast.tw>
