### PR TITLE
chore: 更新允許清單以延長有效期限並新增 Microsoft 網域

### DIFF
--- a/AGH/allow-list.txt
+++ b/AGH/allow-list.txt
@@ -1,6 +1,5 @@
 ! Title: DAST URL Allowlist (AdGuard Home)
-! Updated: 2023-01-06T00:17:35
-! Expires: 1 day (update frequency)
+! Updated: 2025-07-05T:10:15:35
 
 ! DAST Sites
 @@||ansible.dast.tw^
@@ -18,4 +17,15 @@
 @@||h1.dast.tw^
 @@||h2.dast.tw^
 @@||h3.dast.tw^
+
+! Microsoft Sites
+@@||login.microsoftonline.com^
+@@||*.login.microsoftonline.com^
+@@||login.live.com^
+@@||*.msauth.net^
+@@||*.aadcdn.msftauth.net^
+@@||*.aadcdn.msauthimages.net^
+@@||*.logincdn.msftauth.net^
+@@||*.aadcdn.microsoftonline-p.com^
+@@||*.microsoftonline-p.com^
 


### PR DESCRIPTION
- 將允許清單的更新時間戳記更新至 2025 年 7 月 5 日
- 從允許清單的元資料中移除過期行
- 將數個 Microsoft 相關的網域加入允許清單

Signed-off-by: WSL <jackie@dast.tw>
